### PR TITLE
name of the source files must come before pkg-config

### DIFF
--- a/00_declaring_class/c/Makefile
+++ b/00_declaring_class/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c
+	gcc -Wall -o main main.c point.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main

--- a/01_final_derivable_classes/c/Makefile
+++ b/01_final_derivable_classes/c/Makefile
@@ -1,10 +1,10 @@
 all: main-final main-derivable
 
 main-final: main-final.c point-final.c point-final.h
-	gcc -Wall -o main-final `pkg-config --libs --cflags gobject-2.0` main-final.c point-final.c
+	gcc -Wall -o main-final main-final.c point-final.c `pkg-config --libs --cflags gobject-2.0`
 
 main-derivable: main-derivable.c point-derivable.c point-derivable.h
-	gcc -Wall -o main-derivable `pkg-config --libs --cflags gobject-2.0` main-derivable.c point-derivable.c
+	gcc -Wall -o main-derivable main-derivable.c point-derivable.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main-final main-derivable

--- a/02_instantiating_object/c/Makefile
+++ b/02_instantiating_object/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c
+	gcc -Wall -o main main.c point.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main

--- a/04_private_atributes/c/Makefile
+++ b/04_private_atributes/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c
+	gcc -Wall -o main main.c point.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main

--- a/05_public_methods/c/Makefile
+++ b/05_public_methods/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c
+	gcc -Wall -o main main.c point.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main

--- a/06_inheritence/c/Makefile
+++ b/06_inheritence/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h point3d.c point3d.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c point3d.c
+	gcc -Wall -o main main.c point.c point3d.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main

--- a/07_virtual_methods/c/Makefile
+++ b/07_virtual_methods/c/Makefile
@@ -1,5 +1,5 @@
 main: main.c point.c point.h
-	gcc -Wall -o main `pkg-config --libs --cflags gobject-2.0` main.c point.c
+	gcc -Wall -o main main.c point.c `pkg-config --libs --cflags gobject-2.0`
 
 clean:
 	rm -f main


### PR DESCRIPTION
We see linker errors if name of the source files are not specified before `pkg-config`
Reference: [Compiling GLib Applications on UNIX](https://developer.gnome.org/glib/stable/glib-compiling.html)